### PR TITLE
Update Model.md

### DIFF
--- a/documentation/Model.md
+++ b/documentation/Model.md
@@ -2,7 +2,7 @@
 A model is your 3D-object that you designed in your 3D-modelling software. It may include geometry, materials & animations.
 The model class does not extend the Framer Layer class, compared to the Scene class.
 
-_Important: If you're trying to import a model to a scene and you can't see anything being rendered, it's most likely because you have no lights in your scene. Add a light or apply `new MeshNormalMaterial` to the material-property to see your model. See example further down below. If that doesn't help, adjust the model scale-property as it might be too small or too big._
+_Important: If you're trying to import a model to a scene and you can't see anything being rendered, it's most likely because you have no lights in your scene. Add a light or apply `new THREE.MeshNormalMaterial` to the material-property to see your model. See example further down below. If that doesn't help, adjust the model scale-property as it might be too small or too big._
 
 #### Supported File-formats
 - OBJ / MTL
@@ -103,7 +103,7 @@ scene = new Scene
 new Model
   path: 'models/bike.fbx'
   parent: scene
-  material: new MeshNormalMaterial
+  material: new THREE.MeshNormalMaterial
   onLoad: (model) ->
     
     scene.animationLoop = () ->


### PR DESCRIPTION
Not totally sure about this (but it's the only way I've gotten it to work), but I think instances of `MeshNormalMaterial` need `THREE.` in front of them to work. With just `new MeshNormalMaterial` I get `ReferenceError: Can't find variable: MeshNormalMaterial`. This change adds `THREE.` to the documentation.